### PR TITLE
get rid of Object.values() for canReflect.toArray()

### DIFF
--- a/make-simple-store.js
+++ b/make-simple-store.js
@@ -151,7 +151,7 @@ function makeSimpleStore(baseConnection) {
                     toBeDeleted.delete( canReflect.getIdentity(record, this.queryLogic.schema) );
                 }, this);
 
-                this.destroyRecords( canReflect.toArray(toBeDeleted.values() ) );
+                this.destroyRecords( canReflect.toArray(toBeDeleted) );
             }
 
             // the queries that are not consumed by query


### PR DESCRIPTION
Fix IE11 compatibility by using canReflect.toArray() instead of Object.values().