### PR TITLE
Do not check for subsets when it is the universal set

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,8 @@ end_of_line = LF
 indent_style = tab
 trim_trailing_whitespace = false
 insert_final_newline = true
+indent_size = 4
+
+[{*.json,*.yml,*.md}]
+indent_style = space
+indent_size = 2

--- a/can-memory-store-test.js
+++ b/can-memory-store-test.js
@@ -538,5 +538,24 @@ QUnit.test("create, update, destroy all return saved data", function(assert) {
 	});
 });
 
+QUnit.test("Does not do subset comparisons when the superset is the universe", function(assert) {
+	var queryLogic = new QueryLogic({});
+	queryLogic.isSubset = function() {
+		throw new Error("CANNOT COMPARE");
+	};
+
+	var store =  memoryStore({
+		queryLogic: queryLogic
+	});
+	store.updateQueryDataSync([{ query: {}, startIdentity: "123" }]);
+
+	try {
+		store.getListDataSync({ filter: {a: "b"} });
+		assert.ok(true, "Able to getListData with a universal superset");
+	} catch(e) {
+		assert.ok(false, e);
+	}
+});
+
 
 // TODO: make sure we get the right count

--- a/make-simple-store.js
+++ b/make-simple-store.js
@@ -1,6 +1,5 @@
 var canReflect = require("can-reflect");
 
-
 function getItems(data){
 	if(Array.isArray(data)) {
 		return data;
@@ -80,7 +79,8 @@ function makeSimpleStore(baseConnection) {
 
 			for(var i = 0; i < queryData.length; i++) {
         		var checkSet = queryData[i].query;
-        		if( this.queryLogic.isSubset(query, checkSet) ) {
+				if( this.queryLogic.isEqual(checkSet, {}) ||
+					this.queryLogic.isSubset(query, checkSet) ) {
 					superSetQueryData = queryData[i];
         		}
         	}


### PR DESCRIPTION
can-fixture uses the memory store, but its super set is the universal
set. Therefore there isn't a need to check if a query is a subset. Doing
so causes errors when comparisons are made between unknown types.

This is part of https://github.com/canjs/can-query-logic/issues/50