### PR TITLE
Fix query list not emptying correctly on clear

### DIFF
--- a/can-memory-store-test.js
+++ b/can-memory-store-test.js
@@ -25,6 +25,10 @@ QUnit.module("can-memory-store",{
 	}
 });
 
+QUnit.test("list is empty after connection clear", function(assert) {
+	assert.equal(this.connection._queryData.length, 0, "query data is cleared");
+});
+
 QUnit.test("updateListData", function(assert) {
 	var items = [{id: 1, foo:"bar"},{id: 2, foo:"bar"},{id: 3, foo:"bar"}];
 

--- a/can-memory-store.js
+++ b/can-memory-store.js
@@ -11,7 +11,7 @@ module.exports = namespace.memoryStore = function memoryStore(baseConnection){
     canReflect.assignMap(behavior, {
 		clear: function(){
 			this._instances = {};
-			this._queries = [];
+			this._queryData = [];
 		},
 		_queryData: [],
 		updateQueryDataSync: function(queries){


### PR DESCRIPTION
The `clear` method was trying to set the wrong property to an empty list (`queries` vs `queryData`).  This PR is a quick fix.

Closes #13 